### PR TITLE
Sign community statement as up.front

### DIFF
--- a/source/2013-10-statement-community.html.md
+++ b/source/2013-10-statement-community.html.md
@@ -53,6 +53,7 @@ The Ruby Berlin e.V. and friends, namely:
 * RedFrog Conf orga team
 * nerdkunde podcast
 * geekstammtisch podcast
+* up.front orga team
 
 In person:
 


### PR DESCRIPTION
Signing in the name of @upfront-ug (namely @kriesse, @espy, @karlwestin and @maxfell).
